### PR TITLE
Use current protocol for API access

### DIFF
--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,7 +1,7 @@
 import Metolib from '@fmidev/metolib';
 import mapValues from 'lodash.mapvalues';
 
-const API_URL = 'http://opendata.fmi.fi/wfs';
+const API_URL = '//opendata.fmi.fi/wfs';
 const STORED_QUERY_OBSERVATION =
   'fmi::observations::weather::multipointcoverage';
 const STORED_QUERY_FORECAST =


### PR DESCRIPTION
...otherwise when the build is served over HTTPS you'll get a:

> Blocked loading mixed active content “http://opendata.fmi.fi/wfs?request=getFeature&storedquery_id…endtime=2019-09-01T23%3A00%3A00Z&timestep=180&place=Helsinki”